### PR TITLE
Add error number 8261 as 'shadowing-opcode'

### DIFF
--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -5,6 +5,7 @@ export const errorCodes = {
   'code-size': 5574,
   'shadowing': 2519,
   'shadowing-builtin': 2319,
+  'shadowing-opcode': 8261,
   'func-mutability': 2018,
   'license': 1878,
   'pragma-solidity': 3420,


### PR DESCRIPTION
At Balancer we're running into issues where we're using assembly in a [maths library](https://github.com/balancer-labs/balancer-v2-monorepo/blob/5aa5a86c9ab4e1b0d55825e487e8366787bd5e01/pkg/solidity-utils/contracts/math/Math.sol#L54-L69) and so we naturally shadow the `add` and `sub` instructions.

This is a commonly silenced error to the point where [it is no longer raised by the compiler in recent versions](https://github.com/ethereum/solidity/pull/10971).