### PR TITLE
fix: defend against missing errorCode

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -60,6 +60,7 @@ task(TASK_COMPILE_SOLIDITY_CHECK_ERRORS, async ({ output, ...params }: { output:
       if (e.severity !== 'warning' || !e.sourceLocation) {
         return [e];
       }
+      if (!e.errorCode) { return [e]; }
       const rule = classifier.getWarningRule(parseInteger(e.errorCode), e.sourceLocation);
       if (rule === 'off') {
         return [];

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -60,8 +60,7 @@ task(TASK_COMPILE_SOLIDITY_CHECK_ERRORS, async ({ output, ...params }: { output:
       if (e.severity !== 'warning' || !e.sourceLocation) {
         return [e];
       }
-      if (!e.errorCode) { return [e]; }
-      const rule = classifier.getWarningRule(parseInteger(e.errorCode), e.sourceLocation);
+      const rule = classifier.getWarningRule(Number(e.errorCode), e.sourceLocation);
       if (rule === 'off') {
         return [];
       } else if (rule === 'error') {
@@ -74,11 +73,3 @@ task(TASK_COMPILE_SOLIDITY_CHECK_ERRORS, async ({ output, ...params }: { output:
 
   return runSuper({ output, ...params });
 });
-
-function parseInteger(n: string): number {
-  if (/^\d+$/.test(n)) {
-    return Number(n);
-  } else {
-    throw new Error(`Expected integer but got '${n}'`)
-  }
-}


### PR DESCRIPTION
older compilers (0.4) might not emit errorCode.

Probably from having Chainlink contracts in hardhat's dependencies like so:
```
    dependencyCompiler: {
        paths: [
            '@chainlink/contracts/src/v0.4/LinkToken.sol'
```
...I got the following error message:
```
> hardhat compile

An unexpected error occurred:

Error: Expected integer but got 'undefined'
    at parseInteger ([[REDACTED]]/node_modules/hardhat-ignore-warnings/src/plugin.ts:81:11)
    at [[REDACTED]]/node_modules/hardhat-ignore-warnings/src/plugin.ts:63:46
    at Array.flatMap (<anonymous>)
    at OverriddenTaskDefinition._action ([[REDACTED]]/node_modules/hardhat-ignore-warnings/src/plugin.ts:58:28)
    at async Environment._runTaskDefinition ([[REDACTED]]/packages/network-contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:308:14)
    at async Environment.run ([[REDACTED]]/packages/network-contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:156:14)
    at async SimpleTaskDefinition.action ([[REDACTED]]/packages/network-contracts/node_modules/hardhat/src/builtin-tasks/compile.ts:971:7)
    at async Environment._runTaskDefinition ([[REDACTED]]/packages/network-contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:308:14)
    at async Environment.run ([[REDACTED]]/packages/network-contracts/node_modules/hardhat/src/internal/core/runtime-environment.ts:156:14)
    at async [[REDACTED]]/packages/network-contracts/node_modules/hardhat/src/builtin-tasks/compile.ts:421:28
npm ERR! Lifecycle script `build` failed with error:
npm ERR! Error: command failed
npm ERR!   in workspace: @streamr-contracts/network-contracts@2.4.0
npm ERR!   at location: [[REDACTED]]/packages/network-contracts
```

With my one-line fix, it now compiles without errors (and also without the warnings that I've disabled ;) thanks for this great tool!)