### PR TITLE
Add statement-has-no-effect warning id

### DIFF
--- a/contracts/Lock.sol
+++ b/contracts/Lock.sol
@@ -19,6 +19,11 @@ contract Lock {
         // solc-ignore-next-line unused-call-retval
         msg.sender.call("");
     }
+
+    function z2() external pure {
+        // solc-ignore-next-line statement-has-no-effect
+        "hello world";
+    }
 }
 
 // solc-ignore-next-line missing-receive

--- a/src/error-codes.ts
+++ b/src/error-codes.ts
@@ -13,6 +13,7 @@ export const errorCodes = {
   'pragma-solidity': 3420,
   'missing-receive': 3628,
   'transient-storage': 2394,
+  'statement-has-no-effect': 6133,
 } as const;
 
 export type WarningId = number | keyof typeof errorCodes;


### PR DESCRIPTION
New versions of `solidity-coverage` cause this warning when compiling via IR. Should have the ability to handle it.